### PR TITLE
Persisting rotation on resetToValidBounds

### DIFF
--- a/image/src/main/java/com/smarttoolfactory/image/zoom/EnhancedZoomStateImpl.kt
+++ b/image/src/main/java/com/smarttoolfactory/image/zoom/EnhancedZoomStateImpl.kt
@@ -212,7 +212,7 @@ open class BaseEnhancedZoomState constructor(
         val zoom = zoom.coerceAtLeast(1f)
         val bounds = getBounds()
         val pan = pan.coerceIn(-bounds.x..bounds.x, -bounds.y..bounds.y)
-        resetWithAnimation(pan = pan, zoom = zoom)
+        resetWithAnimation(pan = pan, zoom = zoom, rotation = rotation)
         resetTracking()
     }
 


### PR DESCRIPTION
This implementation doesn't perfectly make sure all parts of the image are within bounds because it doesn't take into account how the "bounds" rectangle expands due to the corners rotating around. However, it is a much more intuitive UX than having the rotation completely reset on every move (in my opinion).

For me, this would resolve #4 